### PR TITLE
[WIP] Add Dockerfile for simple containerisation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# Files to ignore when copying into a Docker container
+.dockerignore
+.DS_Store
+.gitignore
+.git
+dist
+Dockerfile
+node_modules
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:carbon
+WORKDIR /usr/src/umi
+COPY . .
+RUN ["npm", "install", "--verbose"]
+RUN ["npm", "install", "cross-env", "--verbose"]
+EXPOSE 8080/tcp
+CMD ["npm", "run", "dev"]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ npm run build
 
 # build for production and view the bundle analyzer report
 npm run build --report
+
+# Build in a Docker container
+docker build -t umi .
+
+# Run in a Docker container (assuming as created/tagged above)
+docker run -p 8080:8080 -it umi
 ```
 
 For detailed explanation on how things work, checkout the [guide](http://vuejs-templates.github.io/webpack/) and [docs for vue-loader](http://vuejs.github.io/vue-loader).


### PR DESCRIPTION
Adds a Dockerfile which creates a Docker container based on the
current node:carbon Docker image and builds the dev version of
Umi to run in it.

Sample usage:

Build the container:
`$ docker build -t umi .`

Run the container:
`$ docker run -p 8080:8080 -it umi`

Assuming all is well, Umi will be listening from the container on
port 8080.

WIP:
 - [x] Add Dockerfile
 - [x] Test ability to run from Docker
 - [ ] Investigate possibility of using production build rather than dev